### PR TITLE
increase minimum cmake on not-windows from 3.3 to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(WIN32)
   # we are linking to object libraries on Windows
   cmake_minimum_required(VERSION 3.12)
 else(WIN32)
-  cmake_minimum_required(VERSION 3.3)
+  cmake_minimum_required(VERSION 3.8)
 endif(WIN32)
 
 # Handle superbuild first


### PR DESCRIPTION
cmake 3.8 is the first version that supports setting the c++17
standard through CXX_STANDARD.
Compare https://cmake.org/cmake/help/v3.7/prop_tgt/CXX_STANDARD.html
vs. https://cmake.org/cmake/help/v3.8/prop_tgt/CXX_STANDARD.html

With the old 3.3 minimum older cmake would error out because cmake itself does not know about the 17 standard, even if the compiler does. 