### PR TITLE
Avoid memory corruption for complex-valued parallel vectors of CompoundSpaces

### DIFF
--- a/parallel/parallelvvector.cpp
+++ b/parallel/parallelvvector.cpp
@@ -489,7 +489,11 @@ namespace ngla
       sub_pardofs = paralleldofs->Range(range);
     
     AutoVector locvec = S_BaseVectorPtr<SCAL>::Range (range);
-    auto vec = make_unique<S_ParallelBaseVectorPtr<SCAL>> (range.Size(), this->EntrySize(),
+    // this->EntrySize() already accounts for the type of SCAL
+    int correctes = this->EntrySize() * sizeof(double) / sizeof(SCAL);
+    auto vec = make_unique<S_ParallelBaseVectorPtr<SCAL>> (range.Size(),
+		                                           // this->EntrySize(), // this line causes a memory corruption
+							   correctes,
                                                            locvec.Memory(), 
                                                            sub_pardofs,
                                                            this->GetParallelStatus());
@@ -510,7 +514,11 @@ namespace ngla
   AutoVector S_ParallelBaseVectorPtr<SCAL> :: Range (DofRange range) const
   {
     AutoVector locvec = S_BaseVectorPtr<SCAL>::Range (range);
-    auto vec = make_unique<S_ParallelBaseVectorPtr<SCAL>> (range.Size(), this->EntrySize(),
+    // this->EntrySize() already accounts for the type of SCAL
+    int correctes = this->EntrySize() * sizeof(double) / sizeof(SCAL);
+    auto vec = make_unique<S_ParallelBaseVectorPtr<SCAL>> (range.Size(),
+		                                           //this->EntrySize(), // this line causes a memory corruption
+							   correctes,
                                                            locvec.Memory(), 
                                                            range.GetParallelDofs(),
                                                            this->GetParallelStatus());


### PR DESCRIPTION
I have found a bug in the MPI version of NGSolve.
When using complex-valued function spaces in a compound space, the gridfunctions are not allocated/called correctly.
This leads to memory leaks and also wrong component gridfunctions. 
You can find a MWE [here](https://github.com/NGSolve/ngsolve/files/5906895/test_mpi.txt).

With this PR, I suggest a bug fix. Thanks for your feedback!
