### PR TITLE
Add VectorialVoxelCoefficientfunction

### DIFF
--- a/fem/voxelcoefficientfunction.cpp
+++ b/fem/voxelcoefficientfunction.cpp
@@ -167,6 +167,56 @@ namespace ngfem
     throw Exception("Real evaluate for complex VoxelCoefficient called!");
   }
 
+  template<typename T>
+  double VectorialVoxelCoefficientFunction<T> :: Evaluate(const BaseMappedIntegrationPoint& ip) const
+  {
+    if constexpr(is_same_v<T, double>)
+    {
+	    Vec<1> res;
+	    Evaluate (ip, res);
+	    return res(0);
+    }
+    throw Exception("Real evaluate for complex VectorialVoxelCoefficient called!");
+  }
+
+  template<typename T>
+  void VectorialVoxelCoefficientFunction<T> :: Evaluate(const BaseMappedIntegrationPoint& ip, FlatVector<double> result) const
+  {
+    int base = 0;
+    for (auto & cf : voxel_cfs)
+      {
+        cf->Evaluate(ip, result.Range(base, base+1));
+        base += 1;
+      }
+  }
+
+
+  template<typename T>
+  void VectorialVoxelCoefficientFunction<T> :: Evaluate(const BaseMappedIntegrationPoint& ip, FlatVector<Complex> result) const
+  {
+    int base = 0;
+    for (auto & cf : voxel_cfs)
+      {
+        cf->Evaluate(ip, result.Range(base, base+1));
+        base += 1;
+      }
+  }
+
+  template<typename T>
+  Complex VectorialVoxelCoefficientFunction<T> :: EvaluateComplex(const BaseMappedIntegrationPoint& ip) const
+  {
+    if constexpr(is_same_v<T, Complex>)
+    {
+	    Vec<1, Complex> res;
+	    Evaluate (ip, res);
+	    return res(0);
+    }
+    throw Exception("Complex evaluate for real VectorialVoxelCoefficient called!");
+
+  }
+
   template class VoxelCoefficientFunction<double>;
   template class VoxelCoefficientFunction<Complex>;
+  template class VectorialVoxelCoefficientFunction<double>;
+  template class VectorialVoxelCoefficientFunction<Complex>;
 } // namespace ngfem

--- a/fem/voxelcoefficientfunction.hpp
+++ b/fem/voxelcoefficientfunction.hpp
@@ -34,6 +34,31 @@ namespace ngfem
   private:
     SCAL T_Evaluate(const BaseMappedIntegrationPoint& ip) const;
   };
+
+  template<typename SCAL>
+  class VectorialVoxelCoefficientFunction : public CoefficientFunctionNoDerivative
+  {
+	  // Array of VoxelCoefficientFunction
+  	  Array<shared_ptr<VoxelCoefficientFunction<SCAL>>> voxel_cfs;
+	  Array<size_t> dimi;  // shape of entries
+
+  public:
+    VectorialVoxelCoefficientFunction() = default;
+    VectorialVoxelCoefficientFunction (Array<shared_ptr<VoxelCoefficientFunction<SCAL>>> avoxel_cfs) : voxel_cfs(avoxel_cfs), dimi(avoxel_cfs.Size())
+    {
+    	for (auto cf : voxel_cfs)
+      	  if (cf && cf->IsComplex())
+            is_complex = true;
+    }
+
+    using CoefficientFunctionNoDerivative::Evaluate;
+    double Evaluate(const BaseMappedIntegrationPoint& ip) const override;
+    Complex EvaluateComplex(const BaseMappedIntegrationPoint& ip) const override;
+    void Evaluate(const BaseMappedIntegrationPoint& mip, FlatVector<> values) const override;
+    void Evaluate(const BaseMappedIntegrationPoint& mip, FlatVector<Complex> values) const override;
+
+  };
+
 } // namespace ngfem
 
 #endif // NGSOLVE_VOXELCOEFFICIENTFUNCTION_HPP

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -49,7 +49,7 @@ from .fem import BFI, LFI, CoefficientFunction, Parameter, ParameterC, ET, \
     VERTEX, FACET, ELEMENT, sin, cos, tan, atan, acos, asin, sinh, cosh, \
     exp, log, sqrt, erf, floor, ceil, Conj, atan2, pow, Sym, Skew, Id, Trace, Inv, Det, Cof, Cross, \
     specialcf, BlockBFI, BlockLFI, CompoundBFI, CompoundLFI, BSpline, \
-    IntegrationRule, IfPos, VoxelCoefficient, CacheCF, PlaceholderCF
+    IntegrationRule, IfPos, VoxelCoefficient, VectorialVoxelCoefficient, CacheCF, PlaceholderCF
 from .comp import VOL, BND, BBND, BBBND, COUPLING_TYPE, ElementId, \
     BilinearForm, LinearForm, GridFunction, Preconditioner, \
     MultiGridPreconditioner, ElementId, FESpace, ProductSpace, H1, HCurl, \

--- a/tests/pytest/test_voxel.py
+++ b/tests/pytest/test_voxel.py
@@ -1,0 +1,236 @@
+import pytest
+from ngsolve import VectorialVoxelCoefficient, Mesh
+from netgen.csg import unit_cube
+from netgen.geom2d import unit_square
+import numpy as np
+
+unit_cube_mesh = Mesh(unit_cube.GenerateMesh(maxh=0.2))
+unit_square_mesh = Mesh(unit_square.GenerateMesh(maxh=0.2))
+
+
+def test_vector_voxelcf_2d():
+    vec_data = np.array([1.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, -1.0]).reshape(2, 2, 2)
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=vec_data, linear=False, shape=(2,))
+    mip = unit_square_mesh(0.1, 0.1)
+    assert np.all(np.isclose(np.array([1.0, 0.0]), vec_vcf(mip)))
+    return
+
+
+def test_vector_voxelcf_2d_complex():
+    vec_data = np.array([1j, 0.0, 0.0, 1j, -1j, 0.0, 0.0, -1j]).reshape(2, 2, 2)
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=vec_data, linear=False, shape=(2,))
+    mip = unit_square_mesh(0.1, 0.1)
+    assert np.all(np.isclose(np.array([1j, 0.0]), vec_vcf(mip)))
+    return
+
+
+def test_vector_voxelcf_3d():
+    # 8 quadrants, 1 voxel per quadrant
+    vec_data = np.array([1.0, 0.0, 0.0,  # x-direction
+                         0.0, 1.0, 0.0,  # y-direction
+                         -1.0, 0.0, 0.0,  # -x-direction
+                         0.0, -1.0, 0.0,  # -y-direction
+                         1.0, 0.0, 1.0,  # xz-direction
+                         0.0, 1.0, 1.0,  # yz-direction
+                         -1.0, 0.0, -1.0,  # -xz-direction
+                         0.0, -1.0, -1.0,  # -yz-direction
+                         ]).reshape(2, 2, 2, 3)
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=vec_data, linear=False, shape=(3,))
+    mip = unit_cube_mesh(0.1, 0.1, 0.1)
+    assert np.all(np.isclose(np.array([1.0, 0.0, 0.0]), vec_vcf(mip)))
+    return
+
+
+def test_vector_voxelcf_3d_complex():
+    # 8 quadrants, 1 voxel per quadrant
+    vec_data = np.array([1j, 0.0, 0.0,  # x-direction
+                         0.0, 1j, 0.0,  # y-direction
+                         -1j, 0.0, 0.0,  # -x-direction
+                         0.0, -1j, 0.0,  # -y-direction
+                         1j, 0.0, 1j,  # xz-direction
+                         0.0, 1j, 1j,  # yz-direction
+                         -1j, 0.0, -1j,  # -xz-direction
+                         0.0, -1j, -1j,  # -yz-direction
+                         ]).reshape(2, 2, 2, 3)
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=vec_data, linear=False, shape=(3,))
+    mip = unit_cube_mesh(0.1, 0.1, 0.1)
+    assert np.all(np.isclose(np.array([1j, 0.0, 0.0]), vec_vcf(mip)))
+    return
+
+
+def test_matrix_voxelcf_2d():
+    mat_data = np.array([1.0, 2.0, 3.0, 4.0,
+                         1.0, 2.0, 3.0, 4.0,
+                         1.0, 2.0, 3.0, 4.0,
+                         1.0, 2.0, 3.0, 4.0]).reshape(2, 2, 2, 2)
+
+    mat_vcf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=mat_data, linear=False, shape=(2, 2))
+    mip = unit_square_mesh(0.1, 0.1)
+    assert np.all(np.isclose(np.array([1.0, 2.0, 3.0, 4.0]), mat_vcf(mip)))
+    return
+
+
+def test_matrix_voxelcf_2d_complex():
+    mat_data = np.array([1.0j, 2.0j, 3.0j, 4.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j]).reshape(2, 2, 2, 2)
+
+    mat_vcf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=mat_data, linear=False, shape=(2, 2))
+    mip = unit_square_mesh(0.1, 0.1)
+    assert np.all(np.isclose(np.array([1.0j, 2.0j, 3.0j, 4.0j]), mat_vcf(mip)))
+    return
+
+
+def test_matrix_voxelcf_3d():
+    mat_data = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                         1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                         1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                         1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                         1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                         1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                         1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                         1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]).reshape(2, 2, 2, 3, 3)
+    mat_vcf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=mat_data, linear=False, shape=(3, 3))
+    mip = unit_cube_mesh(0.1, 0.1, 0.1)
+    assert np.all(np.isclose(np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]), mat_vcf(mip)))
+    return
+
+
+def test_matrix_voxelcf_3d_complex():
+    mat_data = np.array([1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j,
+                         1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j]).reshape(2, 2, 2, 3, 3)
+    mat_vcf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=mat_data, linear=False, shape=(3, 3))
+    mip = unit_cube_mesh(0.1, 0.1, 0.1)
+    assert np.all(np.isclose(np.array([1.0j, 2.0j, 3.0j, 4.0j, 5.0j, 6.0j, 7.0j, 8.0j, 9.0j]), mat_vcf(mip)))
+    return
+
+
+def test_matrix_vec_product_voxelcf_2d():
+    vec_data = np.array([1.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, -1.0]).reshape(2, 2, 2)
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=vec_data, linear=False, shape=(2,))
+    voxel_identity_mat = np.array([1.0, 0.0,
+                                   0.0, 1.0,
+                                   1.0, 0.0,
+                                   0.0, 1.0,
+                                   1.0, 0.0,
+                                   0.0, 1.0,
+                                   1.0, 0.0,
+                                   0.0, 1.0]).reshape(2, 2, 2, 2)
+    voxel_identity_mat_cf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=voxel_identity_mat, linear=False, shape=(2, 2))
+    prod_cf = voxel_identity_mat_cf * vec_vcf
+    mip = unit_square_mesh(0.1, 0.1)
+    assert np.all(np.isclose(prod_cf(mip), vec_vcf(mip)))
+    return
+
+
+def test_matrix_vec_product_voxelcf_2d_complex():
+    vec_data = np.array([1j, 0.0, 0.0, 1j, -1j, 0.0, 0.0, -1j]).reshape(2, 2, 2)
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=vec_data, linear=False, shape=(2,))
+    voxel_identity_mat = np.array([1.0, 0.0,
+                                   0.0, 1.0,
+                                   1.0, 0.0,
+                                   0.0, 1.0,
+                                   1.0, 0.0,
+                                   0.0, 1.0,
+                                   1.0, 0.0,
+                                   0.0, 1.0], dtype=np.complex128).reshape(2, 2, 2, 2)
+    voxel_identity_mat_cf = VectorialVoxelCoefficient(start=(0, 0), end=(1, 1), values=voxel_identity_mat, linear=False, shape=(2, 2))
+    prod_cf = voxel_identity_mat_cf * vec_vcf
+    mip = unit_square_mesh(0.1, 0.1)
+    assert np.all(np.isclose(prod_cf(mip), vec_vcf(mip)))
+    return
+
+
+def test_matrix_vec_product_voxelcf_3d():
+    # 8 quadrants, 1 voxel per quadrant
+    vec_data = np.array([1.0, 0.0, 0.0,  # x-direction
+                         0.0, 1.0, 0.0,  # y-direction
+                         -1.0, 0.0, 0.0,  # -x-direction
+                         0.0, -1.0, 0.0,  # -y-direction
+                         1.0, 0.0, 1.0,  # xz-direction
+                         0.0, 1.0, 1.0,  # yz-direction
+                         -1.0, 0.0, -1.0,  # -xz-direction
+                         0.0, -1.0, -1.0,  # -yz-direction
+                         ]).reshape(2, 2, 2, 3)
+
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=vec_data, linear=False, shape=(3,))
+
+    voxel_identity_mat = np.array([1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0]).reshape(2, 2, 2, 3, 3)
+    voxel_identity_mat_cf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=voxel_identity_mat, linear=False, shape=(3, 3))
+    prod_cf = voxel_identity_mat_cf * vec_vcf
+    mip = unit_cube_mesh(0.1, 0.1, 0.1)
+    assert np.all(np.isclose(prod_cf(mip), vec_vcf(mip)))
+
+
+def test_matrix_vec_product_voxelcf_3d_complex():
+    # 8 quadrants, 1 voxel per quadrant
+    vec_data = np.array([1j, 0.0, 0.0,  # x-direction
+                         0.0, 1j, 0.0,  # y-direction
+                         -1j, 0.0, 0.0,  # -x-direction
+                         0.0, -1j, 0.0,  # -y-direction
+                         1j, 0.0, 1j,  # xz-direction
+                         0.0, 1j, 1j,  # yz-direction
+                         -1j, 0.0, -1j,  # -xz-direction
+                         0.0, -1j, -1j,  # -yz-direction
+                         ]).reshape(2, 2, 2, 3)
+
+    vec_vcf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=vec_data, linear=False, shape=(3,))
+
+    voxel_identity_mat = np.array([1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0,
+                                   1.0, 0.0, 0.0,
+                                   0.0, 1.0, 0.0,
+                                   0.0, 0.0, 1.0], dtype=np.complex128).reshape(2, 2, 2, 3, 3)
+    voxel_identity_mat_cf = VectorialVoxelCoefficient(start=(0, 0, 0), end=(1, 1, 1), values=voxel_identity_mat, linear=False, shape=(3, 3))
+    prod_cf = voxel_identity_mat_cf * vec_vcf
+    mip = unit_cube_mesh(0.1, 0.1, 0.1)
+    assert np.all(np.isclose(prod_cf(mip), vec_vcf(mip)))


### PR DESCRIPTION
I would like to contribute an interface that permits to read in vector- and matrix-valued data from NumPy ndarrays.
This extends the `VoxelCoefficient` that can currently only handle scalar input values.

I closely followed the implementation of the `VectorialCoefficientFunction` interface.
To check the implementation and highlight the Python interface, I added some pytests.
As my C++ knowledge is a bit rusty, I would like to ask you to check the memory allocation and deallocation.