### PR TITLE
small changes to make NgsAMG build

### DIFF
--- a/basiclinalg/expr.hpp
+++ b/basiclinalg/expr.hpp
@@ -1387,7 +1387,7 @@ namespace ngbla
     FlatArray<int> rows;
   public:
     typedef typename TA::TELEM TELEM;
-    // typedef typename TA::TSCAL TSCAL;
+    typedef typename TA::TSCAL TSCAL;
     static constexpr bool IsLinear() { return false; }
     
     INLINE RowsArrayExpr (const TA & aa, FlatArray<int> arows) : a(aa), rows(arows) { ; }
@@ -1435,7 +1435,7 @@ namespace ngbla
   public:
     typedef typename TA::TELEM TELEM;
     static constexpr bool IsLinear() { return false; } 
-    // typedef typename TA::TSCAL TSCAL;
+    typedef typename TA::TSCAL TSCAL;
 
     INLINE ColsArrayExpr (const TA & aa, FlatArray<int> acols) : a(aa), cols(acols) { ; }
 

--- a/linalg/basematrix.hpp
+++ b/linalg/basematrix.hpp
@@ -746,6 +746,7 @@ namespace ngla
     VScaleMatrix (const BaseMatrix & abm, TSCAL ascale) : bm(abm), scale(ascale) { ; }
     VScaleMatrix (shared_ptr<BaseMatrix> aspbm, TSCAL ascale)
       : bm(*aspbm), spbm(aspbm), scale(ascale) { ; }
+    TSCAL GetScalingFactor() const { return scale; }
     virtual bool IsComplex() const override
     { return bm.IsComplex() || typeid(TSCAL)==typeid(Complex); } 
     ///

--- a/linalg/elementbyelement.hpp
+++ b/linalg/elementbyelement.hpp
@@ -52,6 +52,7 @@ namespace ngla
     void SetDisjointCols(bool newval){disjointcols=newval;}
     int VHeight() const override { return height; }
     int VWidth() const override { return width; }
+    size_t GetNumElMats() const { return elmats.Size(); }
 
     AutoVector CreateRowVector () const override { return make_unique<VVector<double>> (width); } 
     AutoVector CreateColVector () const override { return make_unique<VVector<double>> (height); }


### PR DESCRIPTION
This PR adds back some code commented out in expr.hpp, commenting these out made some of the AMG-code not compile anymore. If there is a specific purpose why it was commented out I will have to work around it differently somehow.

Besides that, it adds two small utility getter methods to the el-by-el matrix and scaled matrix.